### PR TITLE
Fix some examples

### DIFF
--- a/examples/button_groups.py
+++ b/examples/button_groups.py
@@ -30,63 +30,65 @@ class Model(HasTraits):
     last_pressed_button = Any(comparison_mode=NO_COMPARE)
     last_released_button = Any(comparison_mode=NO_COMPARE)
 
-    traits_view = View(
-        Bound(
-            VBoxLayout(
-                GroupBox(
-                    VBoxLayout(
-                        PushButton(text=u'Push A', id='push_a'),
-                        PushButton(text=u'Push B', id='push_b'),
-                        PushButton(text=u'Push C', id='push_c'),
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                VBoxLayout(
+                    GroupBox(
+                        VBoxLayout(
+                            PushButton(text=u'Push A', id='push_a'),
+                            PushButton(text=u'Push B', id='push_b'),
+                            PushButton(text=u'Push C', id='push_c'),
+                        ),
+                        title=u'Push Buttons',
                     ),
-                    title=u'Push Buttons',
+                    GroupBox(
+                        VBoxLayout(
+                            RadioButton(text=u'Radio A', id='radio_a',
+                                        checked=True),
+                            RadioButton(text=u'Radio B', id='radio_b'),
+                            RadioButton(text=u'Radio C', id='radio_c'),
+                        ),
+                        title=u'Radio Buttons',
+                    ),
+                    GroupBox(
+                        FormLayout(
+                            (u'Clicked:', Label(id='clicked')),
+                            (u'Pressed:', Label(id='pressed')),
+                            (u'Released:', Label(id='released')),
+                        ),
+                        title=u'Events',
+                    ),
                 ),
-                GroupBox(
-                    VBoxLayout(
-                        RadioButton(text=u'Radio A', id='radio_a',
-                                    checked=True),
-                        RadioButton(text=u'Radio B', id='radio_b'),
-                        RadioButton(text=u'Radio C', id='radio_c'),
-                    ),
-                    title=u'Radio Buttons',
-                ),
-                GroupBox(
-                    FormLayout(
-                        (u'Clicked:', Label(id='clicked')),
-                        (u'Pressed:', Label(id='pressed')),
-                        (u'Released:', Label(id='released')),
-                    ),
-                    title=u'Events',
+                ('push_buttons.buttonClicked_QAbstractButton >> '
+                 'object.last_clicked_button'),
+                ('push_buttons.buttonPressed_QAbstractButton >> '
+                 'object.last_pressed_button'),
+                ('push_buttons.buttonReleased_QAbstractButton >> '
+                 'object.last_released_button'),
+                ('radio_buttons.buttonClicked_QAbstractButton >> '
+                 'object.last_clicked_button'),
+                ('radio_buttons.buttonPressed_QAbstractButton >> '
+                 'object.last_pressed_button'),
+                ('radio_buttons.buttonReleased_QAbstractButton >> '
+                 'object.last_released_button'),
+                ('clicked.text << (object.last_clicked_button).text() '
+                 'if object.last_clicked_button else u""'),
+                ('pressed.text << (object.last_pressed_button).text() '
+                 'if object.last_pressed_button else u""'),
+                ('released.text << (object.last_released_button).text() '
+                 'if object.last_released_button else u""'),
+                button_groups=dict(
+                    push_buttons=ButtonGroup('push_a', 'push_b', 'push_c'),
+                    radio_buttons=ButtonGroup('radio_a', 'radio_b', 'radio_c',
+                                              exclusive=True),
                 ),
             ),
-            ('push_buttons.buttonClicked_QAbstractButton >> '
-             'object.last_clicked_button'),
-            ('push_buttons.buttonPressed_QAbstractButton >> '
-             'object.last_pressed_button'),
-            ('push_buttons.buttonReleased_QAbstractButton >> '
-             'object.last_released_button'),
-            ('radio_buttons.buttonClicked_QAbstractButton >> '
-             'object.last_clicked_button'),
-            ('radio_buttons.buttonPressed_QAbstractButton >> '
-             'object.last_pressed_button'),
-            ('radio_buttons.buttonReleased_QAbstractButton >> '
-             'object.last_released_button'),
-            ('clicked.text << (object.last_clicked_button).text() '
-             'if object.last_clicked_button else u""'),
-            ('pressed.text << (object.last_pressed_button).text() '
-             'if object.last_pressed_button else u""'),
-            ('released.text << (object.last_released_button).text() '
-             'if object.last_released_button else u""'),
-            button_groups=dict(
-                push_buttons=ButtonGroup('push_a', 'push_b', 'push_c'),
-                radio_buttons=ButtonGroup('radio_a', 'radio_b', 'radio_c',
-                                          exclusive=True),
-            ),
-        ),
-        resizable=True,
-        width=200,
-        title=u'Grid Layouts',
-    )
+            resizable=True,
+            width=200,
+            title=u'Button Groups',
+        )
+        return traits_view
 
 
 def main():

--- a/examples/convert_units.py
+++ b/examples/convert_units.py
@@ -74,29 +74,31 @@ class ModelUI(Controller):
         ('deg', u'Degrees'),
     ])
 
-    traits_view = View(
-        VGroup(
-            Bound(
-                TextField(id='input_units'),
-                'valid << object.input_units_valid',
-                'value := object.input_units',
-                label=u'Input units:',
-            ),
-            Bound(
-                HBoxLayout(
-                    CheckBox(id='check'),
-                    EditableComboBox(id='combo'),
+    def default_traits_view(self):
+        traits_view = View(
+            VGroup(
+                Bound(
+                    TextField(id='input_units'),
+                    'valid << object.input_units_valid',
+                    'value := object.input_units',
+                    label=u'Input units:',
                 ),
-                'combo.lineEdit.valid << object.output_units_valid',
-                'combo.values << handler.output_units_recommendations',
-                'combo.enabled << object.convert_units',
-                'check.checked := object.convert_units',
-                'combo.value >> object.output_units',
-                label=u'Convert units:',
+                Bound(
+                    HBoxLayout(
+                        CheckBox(id='check'),
+                        EditableComboBox(id='combo'),
+                    ),
+                    'combo.lineEdit.valid << object.output_units_valid',
+                    'combo.values << handler.output_units_recommendations',
+                    'combo.enabled << object.convert_units',
+                    'check.checked := object.convert_units',
+                    'combo.value >> object.output_units',
+                    label=u'Convert units:',
+                ),
             ),
-        ),
-        buttons=['OK'],
-    )
+            buttons=['OK'],
+        )
+        return traits_view
 
     def _get_output_units_recommendations(self):
         recommendations = []

--- a/examples/grid_layout.py
+++ b/examples/grid_layout.py
@@ -30,44 +30,47 @@ class Model(HasTraits):
     """ We're just showing off layout, so no model traits.
     """
 
-    traits_view = View(
-        Bound(
-            VBoxLayout(
-                GroupBox(
-                    BasicGridLayout(
-                        [u'Always On:', None, LineEdit()],
-                        [u'Enableable:',
-                         CheckBox(id='field_checkbox'),
-                         LineEdit(id='field')],
-                        [u'Left:',
-                         CheckBox(id='left_checkbox'),
-                         (LineEdit(id='left'), Qt.AlignLeft)],
-                        [u'Right:',
-                         CheckBox(id='right_checkbox'),
-                         (LineEdit(id='right'), Qt.AlignRight)],
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                VBoxLayout(
+                    GroupBox(
+                        BasicGridLayout(
+                            [u'Always On:', None, LineEdit()],
+                            [u'Enableable:',
+                             CheckBox(id='field_checkbox'),
+                             LineEdit(id='field')],
+                            [u'Left:',
+                             CheckBox(id='left_checkbox'),
+                             (LineEdit(id='left'), Qt.AlignLeft)],
+                            [u'Right:',
+                             CheckBox(id='right_checkbox'),
+                             (LineEdit(id='right'), Qt.AlignRight)],
+                        ),
+                        title=u'Basic Grid Layout',
                     ),
-                    title=u'Basic Grid Layout',
-                ),
-                GroupBox(
-                    SpanGridLayout(
-                        (PushButton(text=u'(0, 0)'), 0, 0),
-                        (PushButton(text=u'(0, 1) - (0, 2)'), 0, 1, 1, 2),
-                        (PushButton(text=u'(1, 0) - (1, 1)'), 1, 0, 1, 2),
-                        (PushButton(text=u'(1, 2)\N{RIGHTWARDS ARROW TO BAR}'),
-                         1, 2, Qt.AlignRight),
-                        (PushButton(text=u'(2, 0)'), 2, 0),
-                        (PushButton(text=u'(2, 2)'), 2, 2),
+                    GroupBox(
+                        SpanGridLayout(
+                            (PushButton(text=u'(0, 0)'), 0, 0),
+                            (PushButton(text=u'(0, 1) - (0, 2)'), 0, 1, 1, 2),
+                            (PushButton(text=u'(1, 0) - (1, 1)'), 1, 0, 1, 2),
+                            (PushButton(
+                                text=u'(1, 2)\N{RIGHTWARDS ARROW TO BAR}'),
+                             1, 2, Qt.AlignRight),
+                            (PushButton(text=u'(2, 0)'), 2, 0),
+                            (PushButton(text=u'(2, 2)'), 2, 2),
+                        ),
+                        title=u'Span Grid Layout',
                     ),
-                    title=u'Span Grid Layout',
                 ),
+                'field.enabled << field_checkbox.checked',
+                'left.enabled << left_checkbox.checked',
+                'right.enabled << right_checkbox.checked',
             ),
-            'field.enabled << field_checkbox.checked',
-            'left.enabled << left_checkbox.checked',
-            'right.enabled << right_checkbox.checked',
-        ),
-        resizable=True,
-        title=u'Grid Layouts',
-    )
+            resizable=True,
+            title=u'Grid Layouts',
+        )
+        return traits_view
 
 
 def main():

--- a/examples/range_slider.py
+++ b/examples/range_slider.py
@@ -33,30 +33,32 @@ class Model(HasTraits):
     float_value = Float(0.0)
     log_value = Float(1.0)
 
-    traits_view = View(
-        Bound(
-            FormLayout(
-                (u'Integer:', RangeSlider(id='int_slider',
-                                          range=(-100, 100))),
-                (u'Float:', RangeSlider(id='float_slider',
-                                        slider=FloatSlider(),
-                                        range=(-10.0, 10.0))),
-                (u'Log:', RangeSlider(id='log_slider',
-                                      slider=LogSlider(),
-                                      range=(0.5, 2.0))),
-                fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                FormLayout(
+                    (u'Integer:', RangeSlider(id='int_slider',
+                                              range=(-100, 100))),
+                    (u'Float:', RangeSlider(id='float_slider',
+                                            slider=FloatSlider(),
+                                            range=(-10.0, 10.0))),
+                    (u'Log:', RangeSlider(id='log_slider',
+                                          slider=LogSlider(),
+                                          range=(0.5, 2.0))),
+                    fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+                ),
+                'int_slider.value := object.int_value',
+                'float_slider.value := object.float_value',
+                'log_slider.value := object.log_value',
+                # Make the labels align nicely by fixing their widths using
+                # stylesheets.
+                stylesheet=(u'*[binder_class="RangeSlider"] > .QLabel '
+                            u'{min-width: 40px; max-width: 40px;}'),
             ),
-            'int_slider.value := object.int_value',
-            'float_slider.value := object.float_value',
-            'log_slider.value := object.log_value',
-            # Make the labels align nicely by fixing their widths using
-            # stylesheets.
-            stylesheet=(u'*[binder_class="RangeSlider"] > .QLabel '
-                        u'{min-width: 40px; max-width: 40px;}'),
-        ),
-        resizable=True,
-        title=u'Range Sliders',
-    )
+            resizable=True,
+            title=u'Range Sliders',
+        )
+        return traits_view
 
 
 def main():

--- a/examples/range_slider.py
+++ b/examples/range_slider.py
@@ -37,14 +37,19 @@ class Model(HasTraits):
         traits_view = View(
             Bound(
                 FormLayout(
-                    (u'Integer:', RangeSlider(id='int_slider',
-                                              range=(-100, 100))),
-                    (u'Float:', RangeSlider(id='float_slider',
-                                            slider=FloatSlider(),
-                                            range=(-10.0, 10.0))),
-                    (u'Log:', RangeSlider(id='log_slider',
-                                          slider=LogSlider(),
-                                          range=(0.5, 2.0))),
+                    (u'Integer:', RangeSlider(
+                        id='int_slider',
+                        range=(-100, 100))),
+                    (u'Float:', RangeSlider(
+                        id='float_slider',
+                        slider=FloatSlider(),
+                        range=(-10.0, 10.0),
+                        field_format_func=u'{0:.2f}'.format)),
+                    (u'Log:', RangeSlider(
+                        id='log_slider',
+                        slider=LogSlider(),
+                        range=(0.5, 2.0),
+                        field_format_func=u'{0:.6f}'.format)),
                     fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
                 ),
                 'int_slider.value := object.int_value',

--- a/examples/simple_text_field.py
+++ b/examples/simple_text_field.py
@@ -27,22 +27,24 @@ class Model(HasTraits):
     mode = Enum('auto', 'enter')
     value = Unicode()
 
-    traits_view = View(
-        Bound(
-            EnumDropDown(
-                values=[('auto', u'Automatic'),
-                        ('enter', u'On Enter')]),
-            'value := object.mode',
-            label=u'Mode:',
-        ),
-        Item('value', style='readonly'),
-        Bound(
-            TextField(),
-            'mode := object.mode',
-            'value := object.value',
-            label=u'Text:',
-        ),
-    )
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                EnumDropDown(
+                    values=[('auto', u'Automatic'),
+                            ('enter', u'On Enter')]),
+                'value := object.mode',
+                label=u'Mode:',
+            ),
+            Item('value', style='readonly'),
+            Bound(
+                TextField(),
+                'mode := object.mode',
+                'value := object.value',
+                label=u'Text:',
+            ),
+        )
+        return traits_view
 
 
 def main():

--- a/examples/sliders.py
+++ b/examples/sliders.py
@@ -33,30 +33,32 @@ class Model(HasTraits):
     float_value = Float(0.0)
     log_value = Float(1.0)
 
-    traits_view = View(
-        Bound(
-            FormLayout(
-                (u'Integer:', HBoxLayout(
-                    IntSlider(id='int_slider', range=(-100, 100)),
-                    Label(id='int_text', minimumWidth=50))),
-                (u'Float:', HBoxLayout(
-                    FloatSlider(id='float_slider', range=(-10.0, 10.0)),
-                    Label(id='float_text', minimumWidth=50))),
-                (u'Log:', HBoxLayout(
-                    LogSlider(id='log_slider', range=(0.5, 2.0)),
-                    Label(id='log_text', minimumWidth=50))),
-                fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                FormLayout(
+                    (u'Integer:', HBoxLayout(
+                        IntSlider(id='int_slider', range=(-100, 100)),
+                        Label(id='int_text', minimumWidth=50))),
+                    (u'Float:', HBoxLayout(
+                        FloatSlider(id='float_slider', range=(-10.0, 10.0)),
+                        Label(id='float_text', minimumWidth=50))),
+                    (u'Log:', HBoxLayout(
+                        LogSlider(id='log_slider', range=(0.5, 2.0)),
+                        Label(id='log_text', minimumWidth=50))),
+                    fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+                ),
+                'int_slider.value := object.int_value',
+                'int_text.text << str(object.int_value)',
+                'float_slider.value := object.float_value',
+                'float_text.text << u"{:0.2f}".format(object.float_value)',
+                'log_slider.value := object.log_value',
+                'log_text.text << u"{:0.4f}".format(object.log_value)',
             ),
-            'int_slider.value := object.int_value',
-            'int_text.text << str(object.int_value)',
-            'float_slider.value := object.float_value',
-            'float_text.text << u"{:0.2f}".format(object.float_value)',
-            'log_slider.value := object.log_value',
-            'log_text.text << u"{:0.4f}".format(object.log_value)',
-        ),
-        resizable=True,
-        title=u'Sliders',
-    )
+            resizable=True,
+            title=u'Sliders',
+        )
+        return traits_view
 
 
 def main():

--- a/examples/sliders.py
+++ b/examples/sliders.py
@@ -50,7 +50,7 @@ class Model(HasTraits):
             'int_slider.value := object.int_value',
             'int_text.text << str(object.int_value)',
             'float_slider.value := object.float_value',
-            'float_text.text << str(object.float_value)',
+            'float_text.text << u"{:0.2f}".format(object.float_value)',
             'log_slider.value := object.log_value',
             'log_text.text << u"{:0.4f}".format(object.log_value)',
         ),

--- a/examples/traits_ui.py
+++ b/examples/traits_ui.py
@@ -33,27 +33,29 @@ class Model(HasTraits):
     high_bound = Range(low=60, high=100)
     x = Range(low='low_bound', high='high_bound')
 
-    traits_view = View(
-        Bound(
-            FormLayout(
-                (u'Low:',
-                 RangeSlider(id='low', range=(0, 40))),
-                (u'High:',
-                 RangeSlider(id='high', range=(60, 100))),
-                (u'RangeEditor:',
-                 TraitsUI(Item('x'))),
-                fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                FormLayout(
+                    (u'Low:',
+                     RangeSlider(id='low', range=(0, 40))),
+                    (u'High:',
+                     RangeSlider(id='high', range=(60, 100))),
+                    (u'RangeEditor:',
+                     TraitsUI(Item('x'))),
+                    fieldGrowthPolicy=QtGui.QFormLayout.ExpandingFieldsGrow,
+                ),
+                'low.value := object.low_bound',
+                'high.value := object.high_bound',
+                # Make the labels align nicely by fixing their widths using
+                # stylesheets.
+                stylesheet=(u'*[binder_class="RangeSlider"] > .QLabel '
+                            u'{min-width: 30px; max-width: 30px;}'),
             ),
-            'low.value := object.low_bound',
-            'high.value := object.high_bound',
-            # Make the labels align nicely by fixing their widths using
-            # stylesheets.
-            stylesheet=(u'*[binder_class="RangeSlider"] > .QLabel '
-                        u'{min-width: 30px; max-width: 30px;}'),
-        ),
-        resizable=True,
-        title=u'Traits UI Editor',
-    )
+            resizable=True,
+            title=u'Traits UI Editor',
+        )
+        return traits_view
 
 
 def main():

--- a/examples/ui_form.py
+++ b/examples/ui_form.py
@@ -39,24 +39,26 @@ class Model(HasStrictTraits):
     slider_value = Range(-10, 10)
     degrees = Range(0, 359)
 
-    traits_view = View(
-        Bound(
-            UIFile(
-                localfile('form.ui'),
-                overrides=dict(
-                    lineEdit=TextField(validator=QtGui.QIntValidator()),
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                UIFile(
+                    localfile('form.ui'),
+                    overrides=dict(
+                        lineEdit=TextField(validator=QtGui.QIntValidator()),
+                    ),
+                ),
+                'lineEdit.value := object.text',
+                'dial.value := object.degrees',
+                'dial_value.text << format_deg(object.degrees)',
+                'horizontalSlider.value := object.slider_value',
+                extra_context=dict(
+                    format_deg=format_deg,
                 ),
             ),
-            'lineEdit.value := object.text',
-            'dial.value := object.degrees',
-            'dial_value.text << format_deg(object.degrees)',
-            'horizontalSlider.value := object.slider_value',
-            extra_context=dict(
-                format_deg=format_deg,
-            ),
-        ),
-        resizable=True,
-    )
+            resizable=True,
+        )
+        return traits_view
 
 
 if __name__ == '__main__':

--- a/examples/validation.py
+++ b/examples/validation.py
@@ -54,28 +54,30 @@ class Model(HasTraits):
     value = Any(comparison_mode=NO_COMPARE)
     evaluator_func = Callable(int)
 
-    traits_view = View(
-        Bound(
-            FormLayout(
-                (u'Text:', TextField(id='field')),
-                (u'Kind:', EnumDropDown(
-                    id='combo',
-                    values=[
-                        (int, u'Integer'),
-                        (float, u'Float'),
-                    ])),
-                (u'Value:', Label(id='value')),
-                (u'Text:', Label(id='text')),
+    def default_traits_view(self):
+        traits_view = View(
+            Bound(
+                FormLayout(
+                    (u'Text:', TextField(id='field')),
+                    (u'Kind:', EnumDropDown(
+                        id='combo',
+                        values=[
+                            (int, u'Integer'),
+                            (float, u'Float'),
+                        ])),
+                    (u'Value:', Label(id='value')),
+                    (u'Text:', Label(id='text')),
+                ),
+                'field.value := object.text',
+                'combo.value := object.evaluator_func',
+                'field.validator << PythonEvalidator(object.evaluator_func)',
+                'value.text << repr(object.value)',
+                'text.text << object.text',
+                extra_context=dict(PythonEvalidator=PythonEvalidator),
             ),
-            'field.value := object.text',
-            'combo.value := object.evaluator_func',
-            'field.validator << PythonEvalidator(object.evaluator_func)',
-            'value.text << repr(object.value)',
-            'text.text << object.text',
-            extra_context=dict(PythonEvalidator=PythonEvalidator),
-        ),
-        resizable=True,
-    )
+            resizable=True,
+        )
+        return traits_view
 
     @on_trait_change('text,evaluator_func')
     def _update_value(self):

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -439,6 +439,17 @@ class RangeSlider(Composite):
     _high_label = Any()
     _from_text_func = Callable(int)
 
+    def __init__(self, *args, **traits):
+        # Make sure that a `slider` argument gets assigned before anything else
+        # because it will affect what range can be accepted.
+        if 'slider' in traits:
+            slider = traits.pop('slider')
+            super(RangeSlider, self).__init__()
+            self.slider = slider
+            self.trait_set(**traits)
+        else:
+            super(RangeSlider, self).__init__(*args, **traits)
+
     def construct(self):
         self.slider.construct()
         self.field.construct()

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -430,9 +430,16 @@ class RangeSlider(Composite):
     range = Tuple(Any(0), Any(99))
 
     #: The formatting function for the labels.
-    format_func = Callable(six.text_type)
+    label_format_func = Callable(six.text_type)
 
+    #: The formatting function for the text field. This is used only when the
+    #: slider is setting the value.
+    field_format_func = Callable(six.text_type)
+
+    #: The slider widget.
     slider = Instance(BaseSlider, factory=IntSlider, args=())
+
+    #: The field widget.
     field = Instance(LineEdit, args=())
 
     _low_label = Any()
@@ -489,9 +496,11 @@ class RangeSlider(Composite):
                 if self.qobj is not None:
                     self.field.validator.setRange(range[0], range[1])
                     if not isinstance(self.slider, IntSlider):
+                        # Note: this assumes that all sliders other than
+                        # IntSlider have decimal inputs.
                         self.field.validator.setDecimals(16)
-                    self._low_label.setText(self.format_func(range[0]))
-                    self._high_label.setText(self.format_func(range[1]))
+                    self._low_label.setText(self.label_format_func(range[0]))
+                    self._high_label.setText(self.label_format_func(range[1]))
                 self.field.text = six.text_type(value)
                 self.slider.range = range
                 self.slider.value = value
@@ -502,7 +511,7 @@ class RangeSlider(Composite):
             with self.loopback_guard('value'):
                 value = self.slider.value
                 self.value = value
-                self.field.text = six.text_type(value)
+                self.field.text = self.field_format_func(value)
 
     @on_trait_change('field:textEdited')
     def _on_field_text(self, text):


### PR DESCRIPTION
`Bound` works best (and perhaps, "at all") only when we define them inside
`default_traits_view()`. Static `traits_view = View(...)` declarations are
verboten. Otherwise the `Binder()` instances will be shared between all uses of
that `View`! Fixed all of the examples to promote this practice.

I fixed the `RangeSlider` initialization problem described here:
https://github.com/enthought/qt_binder/issues/13#issuecomment-137244458

Added some nicer formatting for the `RangeSlider` field. Python 3's
`float.__str__()` does not truncate to 8 decimals, so some of the examples
which have 1000 slider steps between -10.0 and 10.0 create really ugly values
due to the imperfect conversion from the integer slider value to the floating
point value. @mdickinson I would love some input on the best way to do these
conversions:
https://github.com/enthought/qt_binder/blob/master/qt_binder/widgets.py#L370-L381

Fixes #13 
