### PR TITLE
BUG: Exclude auxiliary classes that from Binder registry as they were not intended to be looked up.

### DIFF
--- a/qt_binder/raw_widgets.py
+++ b/qt_binder/raw_widgets.py
@@ -683,9 +683,11 @@ class ButtonGroup(Binder):
 # These classes are not intended to be automatically looked up from their Qt
 # classes.
 _EXCLUDE_FROM_REGISTRY = [
+    Composite,
+    NChildren,
     SingleChild,
-    WithLayout,
     SpanGridLayout,
+    WithLayout,
 ]
 
 

--- a/qt_binder/raw_widgets.py
+++ b/qt_binder/raw_widgets.py
@@ -680,7 +680,18 @@ class ButtonGroup(Binder):
                 self.qobj.addButton(button, qt_id)
 
 
+# These classes are not intended to be automatically looked up from their Qt
+# classes.
+_EXCLUDE_FROM_REGISTRY = [
+    SingleChild,
+    WithLayout,
+    SpanGridLayout,
+]
+
+
 for obj in vars().values():
+    if obj in _EXCLUDE_FROM_REGISTRY:
+        continue
     if (isinstance(obj, type) and
             issubclass(obj, Binder) and
             obj is not Binder):

--- a/qt_binder/tests/test_raw_widgets.py
+++ b/qt_binder/tests/test_raw_widgets.py
@@ -16,7 +16,8 @@
 import unittest
 
 from ..qt import QtGui
-from ..raw_widgets import GroupBox, HBoxLayout, Label, VBoxLayout
+from ..raw_widgets import BasicGridLayout, GroupBox, HBoxLayout, Label, \
+    VBoxLayout, Widget, binder_registry
 
 
 class TestBoxLayout(unittest.TestCase):
@@ -48,3 +49,14 @@ class TestBoxLayout(unittest.TestCase):
         box.construct()
         box.configure()
         self.assertIs(label.qobj.parent(), box.qobj)
+
+
+class TestBinderRegistry(unittest.TestCase):
+
+    def test_lookup_widget(self):
+        self.assertIs(binder_registry.lookup_by_type(QtGui.QWidget),
+                      Widget)
+
+    def test_lookup_grid_layout(self):
+        self.assertIs(binder_registry.lookup_by_type(QtGui.QGridLayout),
+                      BasicGridLayout)

--- a/qt_binder/tests/test_raw_widgets.py
+++ b/qt_binder/tests/test_raw_widgets.py
@@ -15,9 +15,9 @@
 
 import unittest
 
-from ..qt import QtGui
+from ..qt import QtCore, QtGui
 from ..raw_widgets import BasicGridLayout, GroupBox, HBoxLayout, Label, \
-    VBoxLayout, Widget, binder_registry
+    Object, VBoxLayout, Widget, binder_registry
 
 
 class TestBoxLayout(unittest.TestCase):
@@ -52,6 +52,10 @@ class TestBoxLayout(unittest.TestCase):
 
 
 class TestBinderRegistry(unittest.TestCase):
+
+    def test_lookup_object(self):
+        self.assertIs(binder_registry.lookup_by_type(QtCore.QObject),
+                      Object)
 
     def test_lookup_widget(self):
         self.assertIs(binder_registry.lookup_by_type(QtGui.QWidget),


### PR DESCRIPTION
Fixes #30

@pberkes
