### PR TITLE
BUG: Ignore named root object when loading a .ui file.

### DIFF
--- a/qt_binder/qt/ui_loader.py
+++ b/qt_binder/qt/ui_loader.py
@@ -57,5 +57,11 @@ else:
 
         loader = RecordingUiLoader()
         ui = loader.load(path)
+        names = loader.to_be_bound()
+        # Exclude the root object from this list as it is always bound to the
+        # UIFile itself.
+        self_name = ui.objectName()
+        if self_name in names:
+            names.remove(self_name)
 
-        return ui, loader.to_be_bound()
+        return ui, names

--- a/qt_binder/tests/form.ui
+++ b/qt_binder/tests/form.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>_TestForm</class>
- <widget class="QWidget" name="_TestForm">
+ <class>TestForm</class>
+ <widget class="QWidget" name="TestForm">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Fixes #34

@pberkes
