### PR TITLE
Fix validation of RangeSlider

### DIFF
--- a/qt_binder/testing.py
+++ b/qt_binder/testing.py
@@ -3,7 +3,7 @@ from traits.trait_notifiers import pop_exception_handler, \
     push_exception_handler
 
 
-class _BaseTestWithGui(GuiTestAssistant):
+class BaseTestWithGui(GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/qt_binder/testing.py
+++ b/qt_binder/testing.py
@@ -1,0 +1,14 @@
+from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
+from traits.trait_notifiers import pop_exception_handler, \
+    push_exception_handler
+
+
+class _BaseTestWithGui(GuiTestAssistant):
+
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+        push_exception_handler(reraise_exceptions=True)
+
+    def tearDown(self):
+        pop_exception_handler()
+        GuiTestAssistant.tearDown(self)

--- a/qt_binder/testing.py
+++ b/qt_binder/testing.py
@@ -1,9 +1,15 @@
+from contextlib import contextmanager
+
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from traits.trait_notifiers import pop_exception_handler, \
     push_exception_handler
 
 
 class BaseTestWithGui(GuiTestAssistant):
+    """ Base class for testing Binders.
+
+    Starts a Qt event loop and reraise exceptions during traits event handling.
+    """
 
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -12,3 +18,16 @@ class BaseTestWithGui(GuiTestAssistant):
     def tearDown(self):
         pop_exception_handler()
         GuiTestAssistant.tearDown(self)
+
+    @contextmanager
+    def constructed(self, binder):
+        """ Take care of the lifecycle of a binder.
+
+        Construct and configure a binder on entry, and dispose it at exit.
+        """
+        binder.construct()
+        try:
+            binder.configure()
+            yield binder
+        finally:
+            binder.dispose()

--- a/qt_binder/tests/test_raw_widgets.py
+++ b/qt_binder/tests/test_raw_widgets.py
@@ -64,35 +64,20 @@ class TestBinderRegistry(unittest.TestCase):
 class TestGroupBox(BaseTestWithGui, unittest.TestCase):
 
     def test_group_box_can_be_childless(self):
-        box = GroupBox()
-        box.construct()
-        try:
-            box.configure()
+        with self.constructed(GroupBox()) as box:
             self.assertIsInstance(box.qobj, QtGui.QGroupBox)
-        finally:
-            box.dispose()
 
     def test_groupbox_alignment_works(self):
         # PySide has a bug. Ensure that we work around it.
-        box = GroupBox()
-        box.construct()
-        try:
-            box.configure()
+        with self.constructed(GroupBox()) as box:
             # Test getting.
             box.alignment
             # Test setting.
             box.alignment = QtCore.Qt.AlignLeft
-        finally:
-            box.dispose()
 
 
 class TestQLineEdit(BaseTestWithGui, unittest.TestCase):
 
     def test_slots_with_arguments_work(self):
-        le = LineEdit()
-        le.construct()
-        try:
-            le.configure()
+        with self.constructed(LineEdit()) as le:
             le.textEdited = u'text'
-        finally:
-            le.dispose()

--- a/qt_binder/tests/test_raw_widgets.py
+++ b/qt_binder/tests/test_raw_widgets.py
@@ -15,23 +15,10 @@
 
 import unittest
 
-from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
-from traits.api import pop_exception_handler, push_exception_handler
-
 from ..qt import QtCore, QtGui
 from ..raw_widgets import BasicGridLayout, GroupBox, HBoxLayout, Label, \
     LineEdit, Object, VBoxLayout, Widget, binder_registry
-
-
-class _BaseTestWithGui(GuiTestAssistant):
-
-    def setUp(self):
-        GuiTestAssistant.setUp(self)
-        push_exception_handler(reraise_exceptions=True)
-
-    def tearDown(self):
-        pop_exception_handler()
-        GuiTestAssistant.tearDown(self)
+from ..testing import _BaseTestWithGui
 
 
 class TestBoxLayout(_BaseTestWithGui, unittest.TestCase):

--- a/qt_binder/tests/test_raw_widgets.py
+++ b/qt_binder/tests/test_raw_widgets.py
@@ -18,10 +18,10 @@ import unittest
 from ..qt import QtCore, QtGui
 from ..raw_widgets import BasicGridLayout, GroupBox, HBoxLayout, Label, \
     LineEdit, Object, VBoxLayout, Widget, binder_registry
-from ..testing import _BaseTestWithGui
+from ..testing import BaseTestWithGui
 
 
-class TestBoxLayout(_BaseTestWithGui, unittest.TestCase):
+class TestBoxLayout(BaseTestWithGui, unittest.TestCase):
 
     def test_configure_nested_layout(self):
         # Regression test for a bug that prevented layouts from being nested.
@@ -61,7 +61,7 @@ class TestBinderRegistry(unittest.TestCase):
                       BasicGridLayout)
 
 
-class TestGroupBox(_BaseTestWithGui, unittest.TestCase):
+class TestGroupBox(BaseTestWithGui, unittest.TestCase):
 
     def test_group_box_can_be_childless(self):
         box = GroupBox()
@@ -86,7 +86,7 @@ class TestGroupBox(_BaseTestWithGui, unittest.TestCase):
             box.dispose()
 
 
-class TestQLineEdit(_BaseTestWithGui, unittest.TestCase):
+class TestQLineEdit(BaseTestWithGui, unittest.TestCase):
 
     def test_slots_with_arguments_work(self):
         le = LineEdit()

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -14,23 +14,14 @@
 
 import unittest
 
-from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
-from traits.api import pop_exception_handler, push_exception_handler
 from traits.testing.unittest_tools import UnittestTools
 
+from .test_raw_widgets import _BaseTestWithGui
 from ..qt import QtGui
 from ..widgets import FloatSlider, RangeSlider, TextField
 
 
-class TestTextField(unittest.TestCase, GuiTestAssistant, UnittestTools):
-
-    def setUp(self):
-        GuiTestAssistant.setUp(self)
-        push_exception_handler(reraise_exceptions=True)
-
-    def tearDown(self):
-        pop_exception_handler()
-        GuiTestAssistant.tearDown(self)
+class TestTextField(unittest.TestCase, _BaseTestWithGui, UnittestTools):
 
     def test_traits(self):
         field = TextField()
@@ -48,28 +39,20 @@ class TestTextField(unittest.TestCase, GuiTestAssistant, UnittestTools):
             field.validator = QtGui.QIntValidator(30, 50)
 
             # Set the text field in an invalid state.
-            field.qobj.textEdited.emit('10')
+            field.textEdited = '10'
             self.assertEqual(field.value, '10')
             self.assertEqual(field.valid, False)
 
             # In 'auto' mode, the value and the validity should update
             # automatically even before the user presses "Enter".
-            field.qobj.textEdited.emit('40')
+            field.textEdited = '40'
             self.assertEqual(field.value, '40')
             self.assertEqual(field.valid, True)
         finally:
             field.dispose()
 
 
-class TestRangeSlider(unittest.TestCase, GuiTestAssistant):
-
-    def setUp(self):
-        GuiTestAssistant.setUp(self)
-        push_exception_handler(reraise_exceptions=True)
-
-    def tearDown(self):
-        pop_exception_handler()
-        GuiTestAssistant.tearDown(self)
+class TestRangeSlider(unittest.TestCase, _BaseTestWithGui):
 
     def test_initialization(self):
         # With a random hash seed, this would fail randomly if we didn't take

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -15,7 +15,7 @@
 import unittest
 
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
-from traits.api import Undefined, pop_exception_handler, push_exception_handler
+from traits.api import pop_exception_handler, push_exception_handler
 from traits.testing.unittest_tools import UnittestTools
 
 from ..qt import QtGui

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -16,8 +16,8 @@ import unittest
 
 from traits.testing.unittest_tools import UnittestTools
 
-from .test_raw_widgets import _BaseTestWithGui
 from ..qt import QtGui
+from ..testing import _BaseTestWithGui
 from ..widgets import FloatSlider, RangeSlider, TextField
 
 

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -64,7 +64,9 @@ class TestRangeSlider(unittest.TestCase, GuiTestAssistant):
             slider.configure()
             self.assertEqual(slider.value, 0)
             self.assertEqual(slider.slider.value, 0)
-            slider.field.trait_property_changed('textEdited', Undefined, '20')
+            slider.field.text = '20'
+            slider.field.trait_property_changed(
+                'editingFinished', Undefined, True)
             self.assertEqual(slider.value, 20)
             self.assertEqual(slider.slider.value, 20)
         finally:
@@ -77,19 +79,21 @@ class TestRangeSlider(unittest.TestCase, GuiTestAssistant):
         range_slider.construct()
         try:
             range_slider.configure()
-            slider= range_slider.slider
+            slider = range_slider.slider
             field = range_slider.field
 
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
 
             # State is Intermediate.
-            range_slider.field.trait_property_changed('textEdited', Undefined, '1')
+            field.text = '1'
+            field.trait_property_changed('editingFinished', Undefined, True)
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
 
             # State is Invalid.
-            range_slider.field.trait_property_changed('textEdited', Undefined, '-10')
+            field.text = '-1'
+            field.trait_property_changed('editingFinished', Undefined, True)
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
         finally:

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -48,13 +48,13 @@ class TestTextField(unittest.TestCase, GuiTestAssistant, UnittestTools):
             field.validator = QtGui.QIntValidator(30, 50)
 
             # Set the text field in an invalid state.
-            field.trait_property_changed('textEdited', Undefined, '10')
+            field.qobj.textEdited.emit('10')
             self.assertEqual(field.value, '10')
             self.assertEqual(field.valid, False)
 
             # In 'auto' mode, the value and the validity should update
             # automatically even before the user presses "Enter".
-            field.trait_property_changed('textEdited', Undefined, '40')
+            field.qobj.textEdited.emit('40')
             self.assertEqual(field.value, '40')
             self.assertEqual(field.valid, True)
         finally:
@@ -94,8 +94,7 @@ class TestRangeSlider(unittest.TestCase, GuiTestAssistant):
             self.assertEqual(slider.value, 0)
             self.assertEqual(slider.slider.value, 0)
             slider.field.text = '20'
-            slider.field.trait_property_changed(
-                'editingFinished', Undefined, True)
+            slider.field.editingFinished = True
             self.assertEqual(slider.value, 20)
             self.assertEqual(slider.slider.value, 20)
         finally:
@@ -116,13 +115,13 @@ class TestRangeSlider(unittest.TestCase, GuiTestAssistant):
 
             # State is Intermediate.
             field.text = '1'
-            field.trait_property_changed('editingFinished', Undefined, True)
+            field.editingFinished = True
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
 
             # State is Invalid.
             field.text = '-1'
-            field.trait_property_changed('editingFinished', Undefined, True)
+            field.editingFinished = True
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
         finally:

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -32,10 +32,7 @@ class TestTextField(unittest.TestCase, BaseTestWithGui, UnittestTools):
             field.value = u''
 
     def test_validity_in_auto_mode(self):
-        field = TextField(mode='auto')
-        field.construct()
-        try:
-            field.configure()
+        with self.constructed(TextField(mode='auto')) as field:
             field.validator = QtGui.QIntValidator(30, 50)
 
             # Set the text field in an invalid state.
@@ -48,8 +45,6 @@ class TestTextField(unittest.TestCase, BaseTestWithGui, UnittestTools):
             field.textEdited = '40'
             self.assertEqual(field.value, '40')
             self.assertEqual(field.valid, True)
-        finally:
-            field.dispose()
 
 
 class TestRangeSlider(unittest.TestCase, BaseTestWithGui):
@@ -70,26 +65,19 @@ class TestRangeSlider(unittest.TestCase, BaseTestWithGui):
         self.assertEqual(slider.field.text, u'20')
 
     def test_field_text_edited(self):
-        slider = RangeSlider()
-        slider.construct()
-        try:
-            slider.configure()
+        with self.constructed(RangeSlider()) as slider:
             self.assertEqual(slider.value, 0)
             self.assertEqual(slider.slider.value, 0)
             slider.field.text = '20'
             slider.field.editingFinished = True
             self.assertEqual(slider.value, 20)
             self.assertEqual(slider.slider.value, 20)
-        finally:
-            slider.dispose()
 
     def test_validator_states(self):
         # When the validator is Invalid or Intermediate, the value of the
         # RangeSlider should not change.
         range_slider = RangeSlider(range=(30, 60), value=50)
-        range_slider.construct()
-        try:
-            range_slider.configure()
+        with self.constructed(range_slider):
             slider = range_slider.slider
             field = range_slider.field
 
@@ -107,5 +95,3 @@ class TestRangeSlider(unittest.TestCase, BaseTestWithGui):
             field.editingFinished = True
             self.assertEqual(slider.value, 50)
             self.assertEqual(range_slider.value, 50)
-        finally:
-            range_slider.dispose()

--- a/qt_binder/tests/test_widgets.py
+++ b/qt_binder/tests/test_widgets.py
@@ -17,11 +17,11 @@ import unittest
 from traits.testing.unittest_tools import UnittestTools
 
 from ..qt import QtGui
-from ..testing import _BaseTestWithGui
+from ..testing import BaseTestWithGui
 from ..widgets import FloatSlider, RangeSlider, TextField
 
 
-class TestTextField(unittest.TestCase, _BaseTestWithGui, UnittestTools):
+class TestTextField(unittest.TestCase, BaseTestWithGui, UnittestTools):
 
     def test_traits(self):
         field = TextField()
@@ -52,7 +52,7 @@ class TestTextField(unittest.TestCase, _BaseTestWithGui, UnittestTools):
             field.dispose()
 
 
-class TestRangeSlider(unittest.TestCase, _BaseTestWithGui):
+class TestRangeSlider(unittest.TestCase, BaseTestWithGui):
 
     def test_initialization(self):
         # With a random hash seed, this would fail randomly if we didn't take

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -407,7 +407,7 @@ class RangeSlider(Composite):
     slider = Instance(BaseSlider, factory=IntSlider, args=())
 
     #: The field widget.
-    field = Instance(LineEdit, args=())
+    field = Instance(TextField, args=())
 
     _low_label = Any()
     _high_label = Any()

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -484,10 +484,12 @@ class RangeSlider(Composite):
     def _on_field_text(self, text):
         if 'value' not in self.loopback_guard:
             with self.loopback_guard('value'):
-                try:
-                    value = self._from_text_func(text)
-                except ValueError:
-                    pass
-                else:
-                    self.value = value
-                    self.slider.value = value
+                validity, _, _ = self.field.validator.validate(text, 0)
+                if validity == QtGui.QValidator.Acceptable:
+                    try:
+                        value = self._from_text_func(text)
+                    except ValueError:
+                        pass
+                    else:
+                        self.value = value
+                        self.slider.value = value

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -55,11 +55,20 @@ class TextField(LineEdit):
     def configure(self):
         self.styleSheet = INVALID_STYLE_RULE
 
+    def _update_valid(self, text):
+        """ Update the valid trait based on validation of ``text``.
+        """
+        validator = self.validator
+        if validator is not None:
+            state, fixed, pos = validator.validate(text, len(text))
+            self.valid = (state == validator.Acceptable)
+
     @on_trait_change('textEdited')
     def _on_textEdited(self, text):
         if (self.mode == 'auto' and
                 'value' not in self.loopback_guard):
             with self.loopback_guard('value'):
+                self._update_valid(text)
                 self.value = text
 
     @on_trait_change('editingFinished')
@@ -70,11 +79,7 @@ class TextField(LineEdit):
 
     @on_trait_change('text,validator')
     def _on_text(self):
-        text = self.text
-        validator = self.validator
-        if validator is not None:
-            state, fixed, pos = validator.validate(text, len(text))
-            self.valid = (state == validator.Acceptable)
+        self._update_valid(self.text)
 
     def _value_changed(self, new):
         if 'value' not in self.loopback_guard:

--- a/qt_binder/widgets.py
+++ b/qt_binder/widgets.py
@@ -480,12 +480,11 @@ class RangeSlider(Composite):
                 self.value = value
                 self.field.text = self.field_format_func(value)
 
-    @on_trait_change('field:textEdited')
+    @on_trait_change('field:value')
     def _on_field_text(self, text):
         if 'value' not in self.loopback_guard:
             with self.loopback_guard('value'):
-                validity, _, _ = self.field.validator.validate(text, 0)
-                if validity == QtGui.QValidator.Acceptable:
+                if self.field.valid:
                     try:
                         value = self._from_text_func(text)
                     except ValueError:


### PR DESCRIPTION
What I did in chronological order:
1) When editing the text field, the RangeSlider value should only update if the value is valid
2) Use a `TextField` instead of `LineEdit` to get feedback from the background color
3) Fix a problem with `TextField`: `valid` was not synchronized with `value` when `mode='auto'`
