### PR TITLE
ENH: Add explicit install_requires for running qt_binder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,13 @@
-Traits CHANGELOG
-================
+QtBinder CHANGELOG
+==================
+
+Release 0.2.1
+-------------
+
+Fixes
+
+* Add ``install_requires`` (#46)
+
 
 Release 0.2
 -----------
@@ -34,4 +42,4 @@ Fixes
 Release 0.1
 -----------
 
-`qt_binder` is born!
+``qt_binder`` is born!

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,10 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     use_2to3=True,
+    install_requires=[
+        'six',
+        'traits',
+        'pyface',
+        'traitsui',
+    ],
 )


### PR DESCRIPTION
This is a subset of the `dev_requirements.txt` that omits the dev-only packages.

PySide/PyQt4 are omitted, of course, because the either/or requirement is not expressible in `install_requires` yet.
