### PR TITLE
fix a few python 3 related test errors

### DIFF
--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -33,6 +33,14 @@ NULL_VARIANT_VALUES = {
 }
 
 
+def _to_str(t):
+    if isinstance(t, QtCore.QByteArray):
+        t = bytes(t).decode()
+    else:
+        t = str(t)
+    return t
+
+
 def _slot_name(name):
     return '_{}_property_changed'.format(name)
 
@@ -553,7 +561,7 @@ class Binder(HasStrictTraits):
                 name = renamings.get(qname, qname)
                 if method_name_counts[name] > 1:
                     # Add the argument types to the name to disambiguate.
-                    arg_types = [str(t).rstrip('*')
+                    arg_types = [_to_str(t).rstrip('*')
                                  for t in meta_meth.parameterTypes()]
                     name = '_'.join([name] + arg_types)
                 if name not in seen:

--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -35,7 +35,12 @@ NULL_VARIANT_VALUES = {
 
 def _to_str(t):
     if isinstance(t, QtCore.QByteArray):
-        t = bytes(t).decode()
+        try:
+            # PyQt4
+            t = bytes(t).decode()
+        except TypeError:
+            # PySide
+            t = str(t)
     else:
         t = str(t)
     return t

--- a/qt_binder/raw_widgets.py
+++ b/qt_binder/raw_widgets.py
@@ -693,7 +693,7 @@ _EXCLUDE_FROM_REGISTRY = [
 ]
 
 
-for obj in vars().values():
+for obj in list(vars().values()):
     if obj in _EXCLUDE_FROM_REGISTRY:
         continue
     if (isinstance(obj, type) and

--- a/qt_binder/tests/dummies.py
+++ b/qt_binder/tests/dummies.py
@@ -15,6 +15,7 @@
 """
 
 import abc
+import six
 
 
 class A(object):
@@ -37,8 +38,9 @@ class Mixed(A, D):
     pass
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Abstract(object):
-    __metaclass__ = abc.ABCMeta
+    pass
 
 
 class Concrete(object):

--- a/qt_binder/type_registry.py
+++ b/qt_binder/type_registry.py
@@ -226,7 +226,7 @@ class TypeRegistry(object):
                     return objs
 
         # None of the concrete superclasses. Check the ABCs.
-        for abstract, objs in self.abc_map.iteritems():
+        for abstract, objs in six.iteritems(self.abc_map):
             if issubclass(typ, abstract) and objs:
                 return objs
 


### PR DESCRIPTION
This PR fixes a handful of test failures on Python 3.x

I am not sure of the best solution for the third commit here as I am not entirely sure where the `"destroyed_b'QObject*'"` key name is being generated.  (I am using PyQt4)

The final remaining test failure I get is:

```
======================================================================
FAIL: test_delayed_connection (qt_binder.tests.test_binder.TestBinder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/lee8rx/src/my_git/qt_binder/build/lib/qt_binder/tests/test_binder.py", line 198, in test_delayed_connection
    six.assertCountEqual(self, received, [(), qobj])
  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/six.py", line 667, in assertCountEqual
    return getattr(self, _assertCountEqual)(*args, **kwargs)
AssertionError: Element counts were not equal:
First has 0, Second has 1:  <PyQt4.QtCore.QObject object at 0x11a091b88>
```

I think this is also likely related to the different key name for `destroyed_Qobject`.  I tried adding:
`obj.on_trait_change(handler, "destroyed_b'QObject*'")`
but the call to `ListenerParser` in `on_trait_change` chokes on that string:

```
Exception occurred in traits notification handler for object: <traits.traits_listener.ListenerParser object at 0x108c570f8>, trait: text, old value: , new value: destroyed_b'QObject*'
NoneType
Exception occurred in traits notification handler.
Please check the log file for details.
Traceback (most recent call last):

  File "<ipython-input-3-b17f31bddf44>", line 1, in <module>
    obj.on_trait_change(handler, "destroyed_b'QObject*'")

  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/traits/has_traits.py", line 2575, in on_trait_change
    listener = ListenerParser( name ).listener

  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/traits/traits_listener.py", line 1144, in __init__
    self.text = text

  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/traits/trait_notifiers.py", line 352, in __call__
    handle_exception( object, trait_name, old, new )

  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/traits/trait_notifiers.py", line 165, in _handle_exception
    raise

RuntimeError: No active exception to reraise
```

Any idea on how to appropriately account for this difference in the `destroyed_Qobject` keyname?
