### PR TITLE
PySide2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
     - os: osx
-      env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5"
+      env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 

--- a/etstool.py
+++ b/etstool.py
@@ -151,16 +151,23 @@ def install(runtime, toolkit, environment):
 @click.option('--runtime', default='3.6')
 @click.option('--toolkit', default='pyqt')
 @click.option('--environment', default=None)
-def test(runtime, toolkit, environment):
+@click.argument('test_spec', nargs=-1)
+def test(runtime, toolkit, environment, test_spec):
     """ Run the test suite in a given environment with the specified toolkit.
 
     """
     parameters = get_parameters(runtime, toolkit, environment)
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
-    commands = [
-        "edm run -e {environment} -- coverage run -p -m unittest discover -v qt_binder"
-    ]
+    if len(test_spec) == 0:
+        commands = [
+            "edm run -e {environment} -- coverage run -p -m unittest discover -v qt_binder"
+        ]
+    else:
+        commands = [
+            ("edm run -e {environment} -- coverage run -p -m unittest -v " +
+             " ".join(test_spec))
+        ]
 
     # We run in a tempdir to avoid accidentally picking up wrong package
     # code from a local dir.  We need to ensure a good .coveragerc is in

--- a/etstool.py
+++ b/etstool.py
@@ -101,7 +101,12 @@ dependencies = {
 
 extra_dependencies = {
     # XXX once pyside2 is available in EDM, we will want it here
-    'pyside2': set(),
+    # We require libpng to ensure that we have a consistent set of EDM-provied
+    # libraries. Qt links against libpng, which links to libz. Without
+    # explicitly requiring libpng, the PySide2 Qt will link to the system's
+    # libpng but EDM's libz, and recent Linuxes have more recent libpngs that
+    # require more recent libzs.
+    'pyside2': {'libpng'},
     'pyqt': {'pyqt<4.12'},  # FIXME: build of 4.12-1 appears to be bad
     'pyqt5': {'pyqt5'},
 }

--- a/etstool.py
+++ b/etstool.py
@@ -139,7 +139,7 @@ def install(runtime, toolkit, environment):
     # pip install pyside2, because we don't have it in EDM yet
     if toolkit == 'pyside2':
         commands.append(
-            "edm run -e {environment} -- pip install pyside2"
+            "edm run -e {environment} -- pip install pyside2 shiboken2"
         )
 
     click.echo("Creating environment '{environment}'".format(**parameters))

--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -147,7 +147,13 @@ class QtTrait(TraitType):
         slot = object.__dict__.pop(slot_name, None)
         if slot is not None:
             signal = self._get_signal(object.qobj)
-            signal.disconnect(slot)
+            # FIXME: PySide2 will raise a RuntimeError here, but it will
+            # disconnect the signal. Not sure if there are other problems.
+            try:
+                signal.disconnect(slot)
+            except RuntimeError:
+                if qt_api != 'pyside2':
+                    raise
 
     def _get_signal(self, qobj):
         """ Return the correct bound signal, especially when overloaded.

--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -156,7 +156,7 @@ class QtTrait(TraitType):
         assert self.is_signal
         # The subclass must provide these when is_signal is True
         assert hasattr(self, 'qname') and hasattr(self, 'meta_method')
-        arg_types = self.meta_method.parameterTypes()
+        arg_types = [_to_str(arg) for arg in self.meta_method.parameterTypes()]
         signal = getattr(qobj, _python_name_for_qt_name(self.qname))
         if len(arg_types) == 0:
             return signal

--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -33,14 +33,9 @@ NULL_VARIANT_VALUES = {
 }
 
 
-def _to_str(t):
+def _to_str(t, encoding='ascii'):
     if isinstance(t, QtCore.QByteArray):
-        try:
-            # PyQt4
-            t = bytes(t).decode()
-        except TypeError:
-            # PySide
-            t = str(t)
+        t = t.data().decode(encoding)
     else:
         t = str(t)
     return t

--- a/qt_binder/binder.py
+++ b/qt_binder/binder.py
@@ -216,9 +216,9 @@ class QtProperty(QtTrait):
             return
         old = self.meta_prop.read(qobj)
         if qt_api.startswith('pyside'):
-            # PySide2 has a bug such that it will not set flags properly through
-            # the QMetaProperty mechanism, like for QGroupBox.alignment.
-            # Use names instead.
+            # PySide2 has a bug such that it will not set flags properly
+            # through the QMetaProperty mechanism, like for
+            # QGroupBox.alignment.  Use names instead.
             qname = _python_name_for_qt_name(_to_str(self.meta_prop.name()))
             # The setter is pretty reliably named like this. The getter is
             # sometimes not (e.g. isEditable() instead of editable()), so we
@@ -406,7 +406,8 @@ class QtSignal(QtSlot):
         else:
             # In both PyQt4 and PySide, QMetaMethod.invoke() does not
             # automatically convert the arguments, so emit it directly.
-            getattr(qobj, name).emit(*args)
+            signal = self._get_signal(qobj)
+            signal.emit(*args)
 
 
 class Rename(object):

--- a/qt_binder/qt/__init__.py
+++ b/qt_binder/qt/__init__.py
@@ -1,1 +1,8 @@
 from pyface.qt import is_qt4, is_qt5, qt_api  # noqa
+
+if qt_api == 'pyside2':
+    # Work around https://bugreports.qt.io/browse/PYSIDE-1093
+    from pyface.qt.QtGui import QApplication
+
+    if QApplication.startingUp():
+        app = QApplication([])

--- a/qt_binder/qt/__init__.py
+++ b/qt_binder/qt/__init__.py
@@ -1,7 +1,10 @@
 from pyface.qt import is_qt4, is_qt5, qt_api  # noqa
 
 if qt_api == 'pyside2':
-    # Work around https://bugreports.qt.io/browse/PYSIDE-1093
+    # FIXME: Work around https://bugreports.qt.io/browse/PYSIDE-1093
+    # This is not a general solution, since most other Qt-using libraries might
+    # get run first. But this is sufficient to get the test suite to run for
+    # local development.
     from pyface.qt.QtGui import QApplication
 
     if QApplication.startingUp():

--- a/qt_binder/qt/__init__.py
+++ b/qt_binder/qt/__init__.py
@@ -1,11 +1,1 @@
 from pyface.qt import is_qt4, is_qt5, qt_api  # noqa
-
-if qt_api == 'pyside2':
-    # FIXME: Work around https://bugreports.qt.io/browse/PYSIDE-1093
-    # This is not a general solution, since most other Qt-using libraries might
-    # get run first. But this is sufficient to get the test suite to run for
-    # local development.
-    from pyface.qt.QtGui import QApplication
-
-    if QApplication.startingUp():
-        app = QApplication([])

--- a/qt_binder/qt/ui_loader.py
+++ b/qt_binder/qt/ui_loader.py
@@ -25,7 +25,10 @@ if qt_api.startswith('pyqt'):
 else:
     def load_ui(path):
         from collections import Counter
-        from PySide.QtUiTools import QUiLoader
+        if qt_api == 'pyside':
+            from PySide.QtUiTools import QUiLoader
+        elif qt_api == 'pyside2':
+            from PySide2.QtUiTools import QUiLoader
 
         class RecordingUiLoader(QUiLoader):
             """ Record the names of widgets as they are created.

--- a/qt_binder/tests/test_binder.py
+++ b/qt_binder/tests/test_binder.py
@@ -178,24 +178,22 @@ class TestBinder(unittest.TestCase):
         qobj = obj.qobj
         obj.configure()
 
-        # PyQt4 signal instances are not unique.
-        if qt_api == 'pyside':
-            self.assertIs(obj.destroyed, qobj.destroyed)
-        else:
-            # There is no way to check if a PyQt4.QtCore.pyqtBoundSignal is the
-            # same as another, and obtaining it from the QObject gets you
-            # a different object every time.
-            pass
+        self.assertEqual(type(obj.destroyed), type(qobj.destroyed))
 
         # Check delayed signal.
         qobj.destroyed[QtCore.QObject].emit(qobj)
 
-        # When there are 2 overloads for a signal and one of the is
-        # argumentless, we actually get the single-argument version regardless.
-        # This is actually typically what we want, but I'm noting it because
-        # this behavior did change when we redid the signal implementation to
-        # conform to the limitations of the PyQt5 signal implementation.
-        six.assertCountEqual(self, received, [qobj])
+        if qt_api.startswith('pyqt'):
+            # When there are 2 overloads for a signal and one of the is
+            # argumentless, we actually get the single-argument version regardless.
+            # This is actually typically what we want, but I'm noting it because
+            # this behavior did change when we redid the signal implementation to
+            # conform to the limitations of the PyQt5 signal implementation.
+            six.assertCountEqual(self, received, [qobj])
+        elif qt_api.startswith('pyside'):
+            # But PySides don't, and I haven't found a good way to rationalize
+            # the two.
+            six.assertCountEqual(self, received, [()])
 
         # No signal after removal.
         received[:] = []


### PR DESCRIPTION
PySide2 is essentially supported now, at least for running tests, and with some care.

There is an upstream bug in 5.13.1 (the latest release as of now) that prevents our introspection techniques from working unless if the `QApplication` is initialized in a particular way. I have a workaround that is sufficient for the test suite, but not the examples. This bug has been fixed upstream, but it has not appeared in a release, yet. When a new release comes down, we'll remove the workaround.

There is a difference in behavior of overloaded signal objects (e.g. `destroyed()` vs `destroyed(QObject*)` with PyQt5. In PyQt5 the signal that we listen to via the plain `destroyed` name will give us the full `destroyed(QObject*)` overload, giving us the `QObject` as the argument. In PySide2, we get the argumentless `destroyed()` variant. Because we can no longer specify exactly what signal we want to listen to using the C++-style strings and have to go through the Python `.destroyed[QObject]` style of overloading, it's hard to rationalize the two. I'm not entirely sure what to do about this. It's possible that this current implementation will suffice. Maybe we should document it as a location of undefined behavior for now.