### PR TITLE
Disable macOS builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,22 @@
 language: generic
 dist: xenial
-sudo: false
 services:
   - xvfb
+
+addons:
+  apt:
+    packages:
+    # Qt dependencies
+    - libglu1-mesa-dev
+    - libxkbcommon-x11-0
+    - libxcb-icccm4
+    - libxcb-image0
+    - libxcb-keysyms1
+    - libxcb-randr0
+    - libxcb-render-util0
+    - libxcb-xinerama0
+    - pulseaudio
+    - libpulse-mainloop-glib0
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
-    - os: osx
-      env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
   fast_finish: true
 
 branches:
@@ -36,7 +34,6 @@ before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 
 install:


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration.